### PR TITLE
Add Toggle Feature for Fold Sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,21 @@ Display folding info on sign column
             open = '-',          -- mark the beginning of a fold
             close = '+',         -- show a closed fold
             seps = { '│', '┃' }, -- open fold middle marker
-        }
+        },
+        enabled = true,
     })
+```
+
+## Toggling Foldsign
+
+```vim
+:lua require('nvim-foldsign').toggle_foldsign()
+```
+
+OR setting custom keymap
+
+```lua
+vim.keymap.set('n', '<leader>tf', require('nvim-foldsign').toggle_foldsign )
 ```
 
 ## Highlight Group

--- a/README.md
+++ b/README.md
@@ -40,15 +40,3 @@ vim.keymap.set('n', '<leader>tf', require('nvim-foldsign').toggle_foldsign )
 ## Highlight Group
 
 Just `FoldColumn`
-
-## Support
-
-<a href="https://www.buymeacoffee.com/yaocccc" target="_blank">
-  <img src="https://github.com/yaocccc/yaocccc/raw/master/qr.png">
-</a>
-
-<br>
-
-<a href="https://www.buymeacoffee.com/yaocccc" target="_blank">
-  <img src="https://cdn.buymeacoffee.com/buttons/v2/default-violet.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 200px !important;" >
-</a>

--- a/lua/nvim-foldsign.lua
+++ b/lua/nvim-foldsign.lua
@@ -1,3 +1,5 @@
+local show_foldsigns = true
+
 local M = {
     offset = -2,
     foldsigns = {
@@ -14,7 +16,19 @@ function M.setsign(line, sign)
     )
 end
 
+function M.toggle_foldsigns()
+    show_foldsigns = not show_foldsigns
+    if show_foldsigns then
+        M.foldsign()
+    else
+        vim.api.nvim_buf_clear_namespace(0, M.ns, 0, -1)
+    end
+end
+
 function M.foldsign()
+    if not show_foldsigns then
+        return
+    end
     local topline = vim.fn.line('w0') - 1
     local botline = vim.fn.line('w$')
     vim.api.nvim_buf_clear_namespace(0, M.ns, topline, botline)

--- a/lua/nvim-foldsign.lua
+++ b/lua/nvim-foldsign.lua
@@ -1,12 +1,11 @@
-local show_foldsigns = true
-
 local M = {
     offset = -2,
     foldsigns = {
         close = '+',
         open = '-',
         seps = { '│', '┃' },
-    }
+    },
+    enabled = true
 }
 
 function M.setsign(line, sign)
@@ -17,8 +16,8 @@ function M.setsign(line, sign)
 end
 
 function M.toggle_foldsigns()
-    show_foldsigns = not show_foldsigns
-    if show_foldsigns then
+    M.enabled = not M.enabled
+    if M.enabled then
         M.foldsign()
     else
         vim.api.nvim_buf_clear_namespace(0, M.ns, 0, -1)
@@ -26,7 +25,7 @@ function M.toggle_foldsigns()
 end
 
 function M.foldsign()
-    if not show_foldsigns then
+    if not M.enabled then
         return
     end
     local topline = vim.fn.line('w0') - 1
@@ -60,6 +59,7 @@ function M.setup(opt)
     M.ns = vim.api.nvim_create_namespace('foldsign')
     if opt and opt.foldsigns then M.foldsigns = opt.foldsigns end
     if opt and opt.offset ~= nil then M.offset = opt.offset end
+    if opt and opt.enabled ~= nil then M.enabled = opt.enabled end
     vim.cmd('au VimEnter,WinEnter,BufWinEnter,ModeChanged,CursorMoved,CursorHold * lua require("nvim-foldsign").foldsign()')
 end
 

--- a/lua/nvim-foldsign.lua
+++ b/lua/nvim-foldsign.lua
@@ -15,7 +15,7 @@ function M.setsign(line, sign)
     )
 end
 
-function M.toggle_foldsigns()
+function M.toggle_foldsign()
     M.enabled = not M.enabled
     if M.enabled then
         M.foldsign()


### PR DESCRIPTION
This pull request introduces a feature that allows users to toggle the fold sign in the Neovim plugin. Users can set the fold sign to be enabled or disabled by default. The README file has also been updated with clear instructions on toggling folds and the necessary steps for configuring key mappings.